### PR TITLE
Switch to use struct i2c_driver's .probe()

### DIFF
--- a/imx294.c
+++ b/imx294.c
@@ -1788,7 +1788,7 @@ static struct i2c_driver imx294_i2c_driver = {
 		.of_match_table	= imx294_dt_ids,
 		.pm = &imx294_pm_ops,
 	},
-	.probe_new = imx294_probe,
+	.probe = imx294_probe,
 	.remove = imx294_remove,
 };
 


### PR DESCRIPTION
After commit https://github.com/torvalds/linux/commit/b8a1a4cd5a98a2adf8dfd6902cd98e57d910ee12  ("i2c: Provide a temporary .probe_new() call-back type"), all drivers being converted to .probe_new() and then commit https://github.com/torvalds/linux/commit/03c835f498b540087244a6757e87dfe7ef10999b ("i2c: Switch .probe() to not take an id parameter") convert back to (the new) .probe() to be able to eventually drop.

this can solve the bug in #1

has been tested by @NightFuryAstro